### PR TITLE
:wrench: Fix build error on netlify

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -12,7 +12,7 @@ module.exports =  withStylus({
     publicRuntimeConfig: {
         staticFolder: '/out',
     },*/
-    target: 'serverless',
+    target: 'server',
     webpack (config, options) {
 /*        config.resolve.alias['react'] = 'preact/compat',
         config.resolve.alias['react-dom'] = 'preact/compat',


### PR DESCRIPTION
I set export target from "serverless" to "server" because there's a problem in netlify that you can't set it to others except server. Anyway I'm not sure that will it effect to web's performance? so I will let @aomkirby123 review it again.